### PR TITLE
ライブラリ追加

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -62,6 +62,7 @@
     "react-use": "^17.3.2",
     "regenerator-runtime": "^0.13.9",
     "string-cosine-similarity": "^2.0.1",
+    "subscriptions-transport-ws": "^0.11.0",
     "text-selection-react": "^1.1.8",
     "typescript": "^4.5.4",
     "use-async-effect": "^2.2.5",


### PR DESCRIPTION
npm WARN deprecated subscriptions-transport-ws@0.9.19: The `subscriptions-transport-ws` package is no longer maintained. We recommend you use `graphql-ws` instead. For help migrating Apollo software to `graphql-ws`, see https://www.apollographql.com/docs/apollo-server/data/subscriptions/#switching-from-subscriptions-transport-ws    For general help using `graphql-ws`, see https://github.com/enisdenjo/graphql-ws/blob/master/README.md

と出ているが一旦これで環境際によるエラーが出てなくなるなら・・