### PR TITLE
[main] 英語を書くときにGrammarlyのチェックを追加

### DIFF
--- a/app/components/study/WriteEnglish.tsx
+++ b/app/components/study/WriteEnglish.tsx
@@ -164,7 +164,6 @@ export default (props: Props) => {
         } else {
             return (
                 <div style={{ position: "relative" }}>
-
                     <TextField
                         label={textFieldPlaceholder}
                         multiline
@@ -175,8 +174,6 @@ export default (props: Props) => {
                         onChange={e => setEnglish(e.target.value)}
                     >
                     </TextField>
-
-
                     {renderOtherOptionIcons()}
                 </div>
             )
@@ -199,6 +196,7 @@ export default (props: Props) => {
                     className={styles.ready_modal} onClick={onClickModal}>
                     {firstDescription()}
                 </div>
+
                 <GrammarlyEditorPlugin clientId="client_RaLmowYRtNRZnuGckN9duD">
                     {renderInputView()}
                 </GrammarlyEditorPlugin>

--- a/app/components/study/WriteEnglish.tsx
+++ b/app/components/study/WriteEnglish.tsx
@@ -1,3 +1,4 @@
+import { GrammarlyEditorPlugin } from '@grammarly/editor-sdk-react';
 import AddCircleIcon from '@mui/icons-material/AddCircle';
 import KeyboardAltIcon from '@mui/icons-material/KeyboardAlt';
 import KeyboardVoiceIcon from '@mui/icons-material/KeyboardVoice';
@@ -163,6 +164,7 @@ export default (props: Props) => {
         } else {
             return (
                 <div style={{ position: "relative" }}>
+
                     <TextField
                         label={textFieldPlaceholder}
                         multiline
@@ -173,6 +175,8 @@ export default (props: Props) => {
                         onChange={e => setEnglish(e.target.value)}
                     >
                     </TextField>
+
+
                     {renderOtherOptionIcons()}
                 </div>
             )
@@ -195,8 +199,9 @@ export default (props: Props) => {
                     className={styles.ready_modal} onClick={onClickModal}>
                     {firstDescription()}
                 </div>
-
-                {renderInputView()}
+                <GrammarlyEditorPlugin clientId="client_RaLmowYRtNRZnuGckN9duD">
+                    {renderInputView()}
+                </GrammarlyEditorPlugin>
 
                 {displayTime ?
                     <div><span style={{ width: 50 }}>

--- a/app/package.json
+++ b/app/package.json
@@ -25,6 +25,7 @@
     "@apollo/client": "^3.5.7",
     "@emotion/react": "^11.7.1",
     "@emotion/styled": "^11.6.0",
+    "@grammarly/editor-sdk-react": "^2.0.2",
     "@mui/icons-material": "^5.2.5",
     "@mui/material": "^5.2.7",
     "@mui/styles": "^5.2.3",


### PR DESCRIPTION
英語で書くときに文法ミスが気になったので試しに入れてみました。

# 導入したもの
@grammarly/editor-sdk-react
https://developer.grammarly.com/docs/api/editor-sdk-react/

# プラン
無料でいけそうです。下記の文章気になりますがあまり表示されないですね。
https://developer.grammarly.com/plans
> Users see a prompt to register for a Grammarly account after rating Grammarly four stars or higher

# スクショ
![スクリーンショット 2022-10-05 0 49 01](https://user-images.githubusercontent.com/33086512/193867414-fa33706d-bffa-4ff4-9c74-ba9fe1954c69.png)
