### PR TITLE
プラン解約文言の変更提案

### DIFF
--- a/app/components/price/PlanGroupModal.tsx
+++ b/app/components/price/PlanGroupModal.tsx
@@ -58,12 +58,12 @@ export default () => {
         return <div style={{ marginTop: 20 }}>
             <Typography variant="body1" align="center">
                 <Link onClick={bye} style={{ cursor: "pointer" }}>
-                    退会する
+                    プランを解約する
                 </Link>
             </Typography>
 
             <Typography variant="body1" align="center">
-                ※ プランを変更する場合は必ず１度退会してからプランを変更してください。
+                ※ プランを変更する場合は、必ず１度プランを解約してから変更してください。
             </Typography>
         </div>
     }


### PR DESCRIPTION
### バックグランド
(最初のPRに慣れるという目的のPRになりますが)
先日、ユーザ側としてがっつりプランからMembershipへの移行を考えたときに、気になった点です。

- 「退会する」の文言を押すときに躊躇 => アカウント消去を連想

### 今回の変更提案

- 「退会する」 => 「プランを解約する」
- 「プランを変更する場合は必ず１度退会してからプランを変更してください。」=>「プランを変更する場合は、必ず１度プランを解約してから変更してください」


### レビュー観点
- これまでの経緯をわかっていないので、本当に文言を変更して良いものなのかわかっておらず、また実際にアカウント消去される挙動もあるのかも不明なので、ご意見いただけますと幸いです。
